### PR TITLE
verse: Fixing pagebreak between poemtitle and poembody

### DIFF
--- a/verse/verse.dtx
+++ b/verse/verse.dtx
@@ -1683,7 +1683,7 @@
 %    \begin{macrocode}
 \newcommand{\@vstypeptitle}[1]{%
   \vspace{\beforepoemtitleskip}%
-  {\poemtitlefont #1\par}%
+  {\poemtitlefont #1\par\nopagebreak}%
   \vspace{\afterpoemtitleskip}%
 }
 %    \end{macrocode}


### PR DESCRIPTION
Sometimes Latex puts the title on one page and the poem on the next. \nopagebreak fixes this behaviour.